### PR TITLE
fix: fix weird using 100% of 2 CPU cores.

### DIFF
--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -400,9 +400,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.2"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e54ea8bc3fb1ee042f5aace6e3c6e025d3874866da222930f70ce62aceba0bfa"
+checksum = "a33c2bf77f2df06183c3aa30d1e96c0695a313d4f9c453cc3762a6db39f99200"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",

--- a/desktop/src-tauri/src/main.rs
+++ b/desktop/src-tauri/src/main.rs
@@ -28,24 +28,22 @@ fn main() {
 
     let (tx, rx) = sync_channel(1);
     tauri::Builder::default()
-        .on_window_event(move |event| {
-            match event.window().label() {
-                "preview" => {
-                    if let WindowEvent::CloseRequested { api, .. } = event.event() {
-                        event.window().hide().unwrap();
-                        api.prevent_close();
-                    }
+        .on_window_event(move |event| match event.window().label() {
+            "preview" => {
+                if let WindowEvent::CloseRequested { api, .. } = event.event() {
+                    event.window().hide().unwrap();
+                    api.prevent_close();
                 }
-                "main" => {
-                    if let WindowEvent::CloseRequested { .. } = event.event() {
-                        if let Some(win) = event.window().get_window("preview") {
-                            win.close().unwrap();
-                        }
-                        tx.send(1).expect("Failed to send close signal");
-                    }
-                }
-                _ => (),
             }
+            "main" => {
+                if let WindowEvent::CloseRequested { .. } = event.event() {
+                    if let Some(win) = event.window().get_window("preview") {
+                        win.close().unwrap();
+                    }
+                    tx.send(1).expect("Failed to send close signal");
+                }
+            }
+            _ => (),
         })
         .setup(move |app| {
             let filepath = app


### PR DESCRIPTION
There was a busy loop in the thread that ran the http server while waiting for a shutdown signal. This would cause the app to use 100% of two CPU cores while it was running.

This replaced the thread with two, one that will wait for the shutdown signal, and one that will run the server, and it uses the `unblock()` feature of the `tiny_http` server to gracefully shutdown the server when we get the shutdown signal.