### PR TITLE
Add license

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,15 @@
+## Contributor License Compromise
+
+Independent contributions (i.e. individual pull requests) from anyone other than the Weird team ([Erlend Sogge Heggen](https://github.com/erlend-sh/), [Kapono Haws](https://github.com/zicklag/) & [Joe](https://github.com/hnb-ku)) are dual-licensed as [Polyform NonCommercial](https://polyformproject.org/licenses/noncommercial/1.0.0/) - granted to Weird as the _licensor_ - and [Blue Oak Model License v1.0](https://blueoakcouncil.org/license/1.0.0) (which is [OSI approved](https://opensource.org/license/blue-oak-model-license)).
+
+Meaning, all independent contributors retain ownership of their own contributions, albeit non-exclusively. In other words, your contributions belong equally to the Weird project as they do to you.
+
+## Q&A
+
+#### Why the PolyForm NonCommercial license?
+
+Because Weird wants to serve self-hosters and cloud-subscribers on equal terms. As product developers we believe 'you become what you sell', and we want first and foremost to be software providers, not cloud providers. (Expounding blog post TBA).
+
+#### Why the Blue Oak license for contributors and general utilities?
+
+Blue Oak is a simpler and [more modern alternative](https://writing.kemitchell.com/2019/03/09/Deprecation-Notice.html) to older permissive licenses with equivalent legal implications.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,6 +6,10 @@ Meaning, all independent contributors retain ownership of their own contribution
 
 ## Q&A
 
+#### What is a "Contributor License Compromise"
+
+It is our alternative to a [CLA](https://en.wikipedia.org/wiki/Contributor_License_Agreement) or [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin). The CLC intends to grant the maintainers of Weird the necessary ownership privileges to run a sustainable project whilst providing a low-friction way for external contributors to submit changes without relinquishing ownership of their own contributions.
+
 #### Why the PolyForm NonCommercial license?
 
 Because Weird wants to serve self-hosters and cloud-subscribers on equal terms. As product developers we believe 'you become what you sell', and we want first and foremost to be software providers, not cloud providers. (Expounding blog post TBA).

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,4 @@
+Weird source code is Copyright (c) 2024 Weird team ([Erlend Sogge Heggen](https://github.com/erlend-sh/), [Kapono Haws](https://github.com/zicklag/) & [Joe](https://github.com/hnb-ku)) \
+and licensed as [PolyForm NonCommercial v1.0](https://polyformproject.org/licenses/noncommercial/1.0.0/).
+
+..except for the general utilities of `/example`, `/example2` and `/example3`, which are licensed under [Blue Oak Model License v1.0](https://blueoakcouncil.org/license/1.0.0).


### PR DESCRIPTION
- Adds the PolyForm NonCommercial license
- Adds first draft of our 'Contributor License Compromise'

it should be accompanied by
- a PR template that has a simple [ ] checkbox for contributors to acknowledge their awareness and compliance with our CLC
- a github action that ensures the checkbox has been checked in PRs made by non-team members.

---

For precedence, see for example CrabNebula's [devtools](https://github.com/crabnebula-dev/devtools?tab=License-1-ov-file).