### PR TITLE
Add CI to lint the codebase       

### DIFF
--- a/.dprint.jsonc
+++ b/.dprint.jsonc
@@ -1,14 +1,11 @@
 {
-  "markdown": {
-  },
-  "toml": {
-  },
-  "dockerfile": {
-  },
-  "excludes": [],
-  "plugins": [
-    "https://plugins.dprint.dev/markdown-0.17.1.wasm",
-    "https://plugins.dprint.dev/toml-0.6.2.wasm",
-    "https://plugins.dprint.dev/dockerfile-0.3.2.wasm"
-  ]
+	"markdown": {},
+	"toml": {},
+	"dockerfile": {},
+	"excludes": [],
+	"plugins": [
+		"https://plugins.dprint.dev/markdown-0.17.1.wasm",
+		"https://plugins.dprint.dev/toml-0.6.2.wasm",
+		"https://plugins.dprint.dev/dockerfile-0.3.2.wasm"
+	]
 }

--- a/.dprint.jsonc
+++ b/.dprint.jsonc
@@ -1,0 +1,14 @@
+{
+  "markdown": {
+  },
+  "toml": {
+  },
+  "dockerfile": {
+  },
+  "excludes": [],
+  "plugins": [
+    "https://plugins.dprint.dev/markdown-0.17.1.wasm",
+    "https://plugins.dprint.dev/toml-0.6.2.wasm",
+    "https://plugins.dprint.dev/dockerfile-0.3.2.wasm"
+  ]
+}

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -29,6 +29,6 @@ module.exports = {
 		}
 	],
 	rules: {
-		"@typescript-eslint/no-floating-promises": "error",
+		'@typescript-eslint/no-floating-promises': 'error'
 	}
 };

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,0 +1,31 @@
+name: Lint
+
+on: [push, pull_request]
+
+jobs:
+  code_quality:
+    name: Code quality
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@v4
+
+      - uses: taiki-e/install-action@just
+      - uses: taiki-e/install-action@dprint
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: typos-cli
+
+      - name: Show version information
+        shell: bash
+        run: |
+          just --version
+          dprint --version
+          typos --version
+
+      - name: Lint codebase
+        shell: bash
+        run: |
+          just lint
+          just fmt-check
+

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -16,12 +16,21 @@ jobs:
         with:
           tool: typos-cli
 
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - name: Install dependencies
+        run: |
+          pnpm install
+
       - name: Show version information
         shell: bash
         run: |
           just --version
           dprint --version
           typos --version
+          pnpm --version
 
       - name: Lint codebase
         shell: bash

--- a/.prettierignore
+++ b/.prettierignore
@@ -7,3 +7,5 @@ yarn.lock
 *.yml
 *.yaml
 *.md
+
+static/

--- a/.prettierignore
+++ b/.prettierignore
@@ -2,3 +2,8 @@
 pnpm-lock.yaml
 package-lock.json
 yarn.lock
+
+# Managed by dprint
+*.yml
+*.yaml
+*.md

--- a/.typos.toml
+++ b/.typos.toml
@@ -1,0 +1,2 @@
+[default.extend-words]
+ratatui = "ratatui"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20 as build
+FROM node:20 AS build
 RUN npm i -g pnpm
 COPY . /project
 WORKDIR /project
@@ -8,6 +8,6 @@ FROM node:20
 COPY --from=build /project/build /project
 RUN useradd weird
 RUN echo '{"type": "module"}' > /project/package.json
-RUN chown -R weird:weird /project 
+RUN chown -R weird:weird /project
 USER weird
 CMD ["node", "/project"]

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
-Weird source code is Copyright (c) 2024 Weird team ([Erlend Sogge Heggen](https://github.com/erlend-sh/), [Kapono Haws](https://github.com/zicklag/) & [Joe](https://github.com/hnb-ku)) \
+Weird source code is Copyright (c) 2024 Weird team ([Erlend Sogge Heggen](https://github.com/erlend-sh/), [Kapono Haws](https://github.com/zicklag/) & [Joe](https://github.com/hnb-ku))\
 and licensed as [PolyForm NonCommercial v1.0](https://polyformproject.org/licenses/noncommercial/1.0.0/).
 
 ..except for the general utilities of `/example`, `/example2` and `/example3`, which are licensed under [Blue Oak Model License v1.0](https://blueoakcouncil.org/license/1.0.0).

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -1,15 +1,17 @@
 [package]
 name = "backend"
 version = "0.1.0"
-edition = "2021"
 default-run = "backend"
+edition = "2021"
 
 [dependencies]
-weird = { path = "./weird" }
 anyhow = "1.0.86"
+async-graphql = "7.0.5"
+async-graphql-axum = "7.0.5"
 async-trait = "0.1.80"
 axum = { version = "0.7.5", features = ["multipart"] }
 axum-extra = { version = "0.9.3", features = ["cookie"] }
+bytes = "1.6.0"
 clap = { version = "4.5.4", features = ["derive", "env"] }
 futures = { version = "0.3", default-features = false }
 headers = "0.4.0"
@@ -20,12 +22,10 @@ rand = "0.8.5"
 reqwest = { version = "0.12.4", features = ["json"], default-features = false }
 serde = { version = "1.0.202", features = ["derive"] }
 serde_json = "1.0.117"
+serde_yaml = "0.9.34"
 tokio = { version = "1.37.0", default-features = false, features = ["macros"] }
 tower = { version = "0.4.13", features = ["filter"] }
 tower-http = { version = "0.5.2", features = ["trace"] }
 tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", features = ["fmt", "env-filter"] }
-async-graphql = "7.0.5"
-async-graphql-axum = "7.0.5"
-serde_yaml = "0.9.34"
-bytes = "1.6.0"
+weird = { path = "./weird" }

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM  messense/rust-musl-cross:x86_64-musl as build
+FROM messense/rust-musl-cross:x86_64-musl AS build
 COPY . /home/rust/src
 RUN --mount=type=cache,target=/home/rust/src/target \
     --mount=type=cache,target=/root/.cargo/registry \

--- a/backend/gdata/Cargo.toml
+++ b/backend/gdata/Cargo.toml
@@ -14,10 +14,10 @@ futures = { version = "0.3.30", default-features = false }
 iroh = { version = "0.18.0", default-features = false }
 quic-rpc = "0.10.1"
 quick_cache = "0.5.1"
+serde = { version = "1.0", features = ["derive"], optional = true }
 smallstr = "0.3.0"
 smallvec = "1.13.2"
 ulid = "1.1.2"
-serde = { version = "1.0", features = ["derive"], optional = true }
 
 [dev-dependencies]
 tokio = "1.38.0"

--- a/backend/gdata/gdata_explorer/Cargo.toml
+++ b/backend/gdata/gdata_explorer/Cargo.toml
@@ -4,15 +4,15 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-crossterm = { version = "0.27.0", features = ["event-stream"] }
-ratatui = "0.26.3"
-gdata = { path = "../" }
-clap = { version = "4.5.6", features = ["derive", "env"] }
-iroh = { version = "0.18.0", default-features = false, features = ["fs-store"] }
 anyhow = "1.0.86"
-once_cell = "1.19.0"
-tokio = { version = "1.38.0" }
-futures-timer = "3.0.3"
-futures = "0.3.30"
-bytes = "1.6.0"
 base64 = "0.22.1"
+bytes = "1.6.0"
+clap = { version = "4.5.6", features = ["derive", "env"] }
+crossterm = { version = "0.27.0", features = ["event-stream"] }
+futures = "0.3.30"
+futures-timer = "3.0.3"
+gdata = { path = "../" }
+iroh = { version = "0.18.0", default-features = false, features = ["fs-store"] }
+once_cell = "1.19.0"
+ratatui = "0.26.3"
+tokio = { version = "1.38.0" }

--- a/backend/weird/src/profile.rs
+++ b/backend/weird/src/profile.rs
@@ -613,7 +613,7 @@ impl<S> Weird<S> {
             // TODO: Wait Until Remote Instance Has Been Synced
             //
             // Currently there will be an error looking up a user the first time we connect to a
-            // remote instance beause we haven't waited until the instance is synced before trying
+            // remote instance because we haven't waited until the instance is synced before trying
             // to access the profile data.
             self.node.docs().import(ticket).await?;
             Ok(ns)

--- a/deploy/rauthy/Dockerfile
+++ b/deploy/rauthy/Dockerfile
@@ -3,4 +3,3 @@ FROM scratch
 COPY --from=rauthy /app/rauthy /
 COPY --from=rauthy /app/rauthy.cfg /
 CMD "/idontexist"
-

--- a/justfile
+++ b/justfile
@@ -39,4 +39,5 @@ fmt-check:
 # Lint the codebase.
 lint:
     pnpm run lint
+    # Run `typos  --write-changes` to fix the mistakes
     typos

--- a/justfile
+++ b/justfile
@@ -1,0 +1,42 @@
+#!/usr/bin/env -S just --justfile
+
+set dotenv-load := true
+
+alias d := dev
+alias f := fmt
+alias l := lint
+alias c := comply
+alias k := check
+
+# List available commands.
+_default:
+    just --list --unsorted
+
+# Setup the repository.
+setup:
+    docker compose up -d
+    pnpm i
+
+# Tasks to make the code-base comply with the rules. Mostly used in git hooks.
+comply: fmt lint
+
+# Check if the repository comply with the rules and ready to be pushed.
+check: fmt-check lint
+
+# Develop the app.
+dev:
+    pnpm run dev
+
+# Format the codebase.
+fmt:
+    pnpm run format
+    dprint fmt
+
+# Check is the codebase properly formatted.
+fmt-check:
+    dprint check
+
+# Lint the codebase.
+lint:
+    pnpm run lint
+    typos

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
 		"preview": "vite preview",
 		"check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
 		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
-		"lint": "prettier --check . --log-level warn && eslint .",
+		"lint": "prettier --check . --log-level warn",
 		"format": "prettier --write . --log-level warn"
 	},
 	"devDependencies": {

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
 		"preview": "vite preview",
 		"check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
 		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
-		"lint": "prettier --check . && eslint .",
-		"format": "prettier --write ."
+		"lint": "prettier --check . --log-level warn && eslint .",
+		"format": "prettier --write . --log-level warn"
 	},
 	"devDependencies": {
 		"@skeletonlabs/skeleton": "^2.10.0",

--- a/src/app.css
+++ b/src/app.css
@@ -2,4 +2,3 @@
 @tailwind components;
 @tailwind utilities;
 @tailwind variants;
-

--- a/src/lib/spow/spow-wasm.d.ts
+++ b/src/lib/spow/spow-wasm.d.ts
@@ -1,8 +1,8 @@
 /* tslint:disable */
 /* eslint-disable */
 /**
-* Calculates the Proof of Work for the given challenge
-* @param {string} challenge
-* @returns {Promise<string | undefined>}
-*/
+ * Calculates the Proof of Work for the given challenge
+ * @param {string} challenge
+ * @returns {Promise<string | undefined>}
+ */
 export function pow_work_wasm(challenge: string): Promise<string | undefined>;

--- a/src/lib/spow/spow-wasm.js
+++ b/src/lib/spow/spow-wasm.js
@@ -1,4 +1,4 @@
-import * as wasm from "./spow-wasm_bg.wasm";
-import { __wbg_set_wasm } from "./spow-wasm_bg.js";
+import * as wasm from './spow-wasm_bg.wasm';
+import { __wbg_set_wasm } from './spow-wasm_bg.js';
 __wbg_set_wasm(wasm);
-export * from "./spow-wasm_bg.js";
+export * from './spow-wasm_bg.js';

--- a/src/lib/spow/spow-wasm_bg.js
+++ b/src/lib/spow/spow-wasm_bg.js
@@ -1,30 +1,32 @@
 let wasm;
 export function __wbg_set_wasm(val) {
-    wasm = val;
+	wasm = val;
 }
-
 
 const heap = new Array(128).fill(undefined);
 
 heap.push(undefined, null, true, false);
 
-function getObject(idx) { return heap[idx]; }
+function getObject(idx) {
+	return heap[idx];
+}
 
 let heap_next = heap.length;
 
 function dropObject(idx) {
-    if (idx < 132) return;
-    heap[idx] = heap_next;
-    heap_next = idx;
+	if (idx < 132) return;
+	heap[idx] = heap_next;
+	heap_next = idx;
 }
 
 function takeObject(idx) {
-    const ret = getObject(idx);
-    dropObject(idx);
-    return ret;
+	const ret = getObject(idx);
+	dropObject(idx);
+	return ret;
 }
 
-const lTextDecoder = typeof TextDecoder === 'undefined' ? (0, module.require)('util').TextDecoder : TextDecoder;
+const lTextDecoder =
+	typeof TextDecoder === 'undefined' ? (0, module.require)('util').TextDecoder : TextDecoder;
 
 let cachedTextDecoder = new lTextDecoder('utf-8', { ignoreBOM: true, fatal: true });
 
@@ -33,246 +35,268 @@ cachedTextDecoder.decode();
 let cachedUint8Memory0 = null;
 
 function getUint8Memory0() {
-    if (cachedUint8Memory0 === null || cachedUint8Memory0.byteLength === 0) {
-        cachedUint8Memory0 = new Uint8Array(wasm.memory.buffer);
-    }
-    return cachedUint8Memory0;
+	if (cachedUint8Memory0 === null || cachedUint8Memory0.byteLength === 0) {
+		cachedUint8Memory0 = new Uint8Array(wasm.memory.buffer);
+	}
+	return cachedUint8Memory0;
 }
 
 function getStringFromWasm0(ptr, len) {
-    ptr = ptr >>> 0;
-    return cachedTextDecoder.decode(getUint8Memory0().subarray(ptr, ptr + len));
+	ptr = ptr >>> 0;
+	return cachedTextDecoder.decode(getUint8Memory0().subarray(ptr, ptr + len));
 }
 
 function addHeapObject(obj) {
-    if (heap_next === heap.length) heap.push(heap.length + 1);
-    const idx = heap_next;
-    heap_next = heap[idx];
+	if (heap_next === heap.length) heap.push(heap.length + 1);
+	const idx = heap_next;
+	heap_next = heap[idx];
 
-    heap[idx] = obj;
-    return idx;
+	heap[idx] = obj;
+	return idx;
 }
 
 function makeMutClosure(arg0, arg1, dtor, f) {
-    const state = { a: arg0, b: arg1, cnt: 1, dtor };
-    const real = (...args) => {
-        // First up with a closure we increment the internal reference
-        // count. This ensures that the Rust closure environment won't
-        // be deallocated while we're invoking it.
-        state.cnt++;
-        const a = state.a;
-        state.a = 0;
-        try {
-            return f(a, state.b, ...args);
-        } finally {
-            if (--state.cnt === 0) {
-                wasm.__wbindgen_export_0.get(state.dtor)(a, state.b);
+	const state = { a: arg0, b: arg1, cnt: 1, dtor };
+	const real = (...args) => {
+		// First up with a closure we increment the internal reference
+		// count. This ensures that the Rust closure environment won't
+		// be deallocated while we're invoking it.
+		state.cnt++;
+		const a = state.a;
+		state.a = 0;
+		try {
+			return f(a, state.b, ...args);
+		} finally {
+			if (--state.cnt === 0) {
+				wasm.__wbindgen_export_0.get(state.dtor)(a, state.b);
+			} else {
+				state.a = a;
+			}
+		}
+	};
+	real.original = state;
 
-            } else {
-                state.a = a;
-            }
-        }
-    };
-    real.original = state;
-
-    return real;
+	return real;
 }
 function __wbg_adapter_16(arg0, arg1, arg2) {
-    wasm.wasm_bindgen__convert__closures__invoke1_mut__h2e9cd75cf14ef9ff(arg0, arg1, addHeapObject(arg2));
+	wasm.wasm_bindgen__convert__closures__invoke1_mut__h2e9cd75cf14ef9ff(
+		arg0,
+		arg1,
+		addHeapObject(arg2)
+	);
 }
 
 let WASM_VECTOR_LEN = 0;
 
-const lTextEncoder = typeof TextEncoder === 'undefined' ? (0, module.require)('util').TextEncoder : TextEncoder;
+const lTextEncoder =
+	typeof TextEncoder === 'undefined' ? (0, module.require)('util').TextEncoder : TextEncoder;
 
 let cachedTextEncoder = new lTextEncoder('utf-8');
 
-const encodeString = (typeof cachedTextEncoder.encodeInto === 'function'
-    ? function (arg, view) {
-    return cachedTextEncoder.encodeInto(arg, view);
-}
-    : function (arg, view) {
-    const buf = cachedTextEncoder.encode(arg);
-    view.set(buf);
-    return {
-        read: arg.length,
-        written: buf.length
-    };
-});
+const encodeString =
+	typeof cachedTextEncoder.encodeInto === 'function'
+		? function (arg, view) {
+				return cachedTextEncoder.encodeInto(arg, view);
+			}
+		: function (arg, view) {
+				const buf = cachedTextEncoder.encode(arg);
+				view.set(buf);
+				return {
+					read: arg.length,
+					written: buf.length
+				};
+			};
 
 function passStringToWasm0(arg, malloc, realloc) {
+	if (realloc === undefined) {
+		const buf = cachedTextEncoder.encode(arg);
+		const ptr = malloc(buf.length, 1) >>> 0;
+		getUint8Memory0()
+			.subarray(ptr, ptr + buf.length)
+			.set(buf);
+		WASM_VECTOR_LEN = buf.length;
+		return ptr;
+	}
 
-    if (realloc === undefined) {
-        const buf = cachedTextEncoder.encode(arg);
-        const ptr = malloc(buf.length, 1) >>> 0;
-        getUint8Memory0().subarray(ptr, ptr + buf.length).set(buf);
-        WASM_VECTOR_LEN = buf.length;
-        return ptr;
-    }
+	let len = arg.length;
+	let ptr = malloc(len, 1) >>> 0;
 
-    let len = arg.length;
-    let ptr = malloc(len, 1) >>> 0;
+	const mem = getUint8Memory0();
 
-    const mem = getUint8Memory0();
+	let offset = 0;
 
-    let offset = 0;
+	for (; offset < len; offset++) {
+		const code = arg.charCodeAt(offset);
+		if (code > 0x7f) break;
+		mem[ptr + offset] = code;
+	}
 
-    for (; offset < len; offset++) {
-        const code = arg.charCodeAt(offset);
-        if (code > 0x7F) break;
-        mem[ptr + offset] = code;
-    }
+	if (offset !== len) {
+		if (offset !== 0) {
+			arg = arg.slice(offset);
+		}
+		ptr = realloc(ptr, len, (len = offset + arg.length * 3), 1) >>> 0;
+		const view = getUint8Memory0().subarray(ptr + offset, ptr + len);
+		const ret = encodeString(arg, view);
 
-    if (offset !== len) {
-        if (offset !== 0) {
-            arg = arg.slice(offset);
-        }
-        ptr = realloc(ptr, len, len = offset + arg.length * 3, 1) >>> 0;
-        const view = getUint8Memory0().subarray(ptr + offset, ptr + len);
-        const ret = encodeString(arg, view);
+		offset += ret.written;
+	}
 
-        offset += ret.written;
-    }
-
-    WASM_VECTOR_LEN = offset;
-    return ptr;
+	WASM_VECTOR_LEN = offset;
+	return ptr;
 }
 /**
-* Calculates the Proof of Work for the given challenge
-* @param {string} challenge
-* @returns {Promise<string | undefined>}
-*/
+ * Calculates the Proof of Work for the given challenge
+ * @param {string} challenge
+ * @returns {Promise<string | undefined>}
+ */
 export function pow_work_wasm(challenge) {
-    const ptr0 = passStringToWasm0(challenge, wasm.__wbindgen_malloc, wasm.__wbindgen_realloc);
-    const len0 = WASM_VECTOR_LEN;
-    const ret = wasm.pow_work_wasm(ptr0, len0);
-    return takeObject(ret);
+	const ptr0 = passStringToWasm0(challenge, wasm.__wbindgen_malloc, wasm.__wbindgen_realloc);
+	const len0 = WASM_VECTOR_LEN;
+	const ret = wasm.pow_work_wasm(ptr0, len0);
+	return takeObject(ret);
 }
 
 function handleError(f, args) {
-    try {
-        return f.apply(this, args);
-    } catch (e) {
-        wasm.__wbindgen_exn_store(addHeapObject(e));
-    }
+	try {
+		return f.apply(this, args);
+	} catch (e) {
+		wasm.__wbindgen_exn_store(addHeapObject(e));
+	}
 }
 function __wbg_adapter_28(arg0, arg1, arg2, arg3) {
-    wasm.wasm_bindgen__convert__closures__invoke2_mut__h34cef696552b2b1d(arg0, arg1, addHeapObject(arg2), addHeapObject(arg3));
+	wasm.wasm_bindgen__convert__closures__invoke2_mut__h34cef696552b2b1d(
+		arg0,
+		arg1,
+		addHeapObject(arg2),
+		addHeapObject(arg3)
+	);
 }
 
 export function __wbindgen_object_drop_ref(arg0) {
-    takeObject(arg0);
-};
+	takeObject(arg0);
+}
 
 export function __wbindgen_string_new(arg0, arg1) {
-    const ret = getStringFromWasm0(arg0, arg1);
-    return addHeapObject(ret);
-};
+	const ret = getStringFromWasm0(arg0, arg1);
+	return addHeapObject(ret);
+}
 
 export function __wbg_queueMicrotask_adae4bc085237231(arg0) {
-    const ret = getObject(arg0).queueMicrotask;
-    return addHeapObject(ret);
-};
+	const ret = getObject(arg0).queueMicrotask;
+	return addHeapObject(ret);
+}
 
 export function __wbindgen_is_function(arg0) {
-    const ret = typeof(getObject(arg0)) === 'function';
-    return ret;
-};
+	const ret = typeof getObject(arg0) === 'function';
+	return ret;
+}
 
 export function __wbindgen_cb_drop(arg0) {
-    const obj = takeObject(arg0).original;
-    if (obj.cnt-- == 1) {
-        obj.a = 0;
-        return true;
-    }
-    const ret = false;
-    return ret;
-};
+	const obj = takeObject(arg0).original;
+	if (obj.cnt-- == 1) {
+		obj.a = 0;
+		return true;
+	}
+	const ret = false;
+	return ret;
+}
 
 export function __wbg_queueMicrotask_4d890031a6a5a50c(arg0) {
-    queueMicrotask(getObject(arg0));
-};
+	queueMicrotask(getObject(arg0));
+}
 
-export function __wbg_self_f0e34d89f33b99fd() { return handleError(function () {
-    const ret = self.self;
-    return addHeapObject(ret);
-}, arguments) };
+export function __wbg_self_f0e34d89f33b99fd() {
+	return handleError(function () {
+		const ret = self.self;
+		return addHeapObject(ret);
+	}, arguments);
+}
 
-export function __wbg_window_d3b084224f4774d7() { return handleError(function () {
-    const ret = window.window;
-    return addHeapObject(ret);
-}, arguments) };
+export function __wbg_window_d3b084224f4774d7() {
+	return handleError(function () {
+		const ret = window.window;
+		return addHeapObject(ret);
+	}, arguments);
+}
 
-export function __wbg_globalThis_9caa27ff917c6860() { return handleError(function () {
-    const ret = globalThis.globalThis;
-    return addHeapObject(ret);
-}, arguments) };
+export function __wbg_globalThis_9caa27ff917c6860() {
+	return handleError(function () {
+		const ret = globalThis.globalThis;
+		return addHeapObject(ret);
+	}, arguments);
+}
 
-export function __wbg_global_35dfdd59a4da3e74() { return handleError(function () {
-    const ret = global.global;
-    return addHeapObject(ret);
-}, arguments) };
+export function __wbg_global_35dfdd59a4da3e74() {
+	return handleError(function () {
+		const ret = global.global;
+		return addHeapObject(ret);
+	}, arguments);
+}
 
 export function __wbindgen_is_undefined(arg0) {
-    const ret = getObject(arg0) === undefined;
-    return ret;
-};
+	const ret = getObject(arg0) === undefined;
+	return ret;
+}
 
 export function __wbg_newnoargs_c62ea9419c21fbac(arg0, arg1) {
-    const ret = new Function(getStringFromWasm0(arg0, arg1));
-    return addHeapObject(ret);
-};
+	const ret = new Function(getStringFromWasm0(arg0, arg1));
+	return addHeapObject(ret);
+}
 
-export function __wbg_call_90c26b09837aba1c() { return handleError(function (arg0, arg1) {
-    const ret = getObject(arg0).call(getObject(arg1));
-    return addHeapObject(ret);
-}, arguments) };
+export function __wbg_call_90c26b09837aba1c() {
+	return handleError(function (arg0, arg1) {
+		const ret = getObject(arg0).call(getObject(arg1));
+		return addHeapObject(ret);
+	}, arguments);
+}
 
 export function __wbindgen_object_clone_ref(arg0) {
-    const ret = getObject(arg0);
-    return addHeapObject(ret);
-};
+	const ret = getObject(arg0);
+	return addHeapObject(ret);
+}
 
-export function __wbg_call_5da1969d7cd31ccd() { return handleError(function (arg0, arg1, arg2) {
-    const ret = getObject(arg0).call(getObject(arg1), getObject(arg2));
-    return addHeapObject(ret);
-}, arguments) };
+export function __wbg_call_5da1969d7cd31ccd() {
+	return handleError(function (arg0, arg1, arg2) {
+		const ret = getObject(arg0).call(getObject(arg1), getObject(arg2));
+		return addHeapObject(ret);
+	}, arguments);
+}
 
 export function __wbg_new_60f57089c7563e81(arg0, arg1) {
-    try {
-        var state0 = {a: arg0, b: arg1};
-        var cb0 = (arg0, arg1) => {
-            const a = state0.a;
-            state0.a = 0;
-            try {
-                return __wbg_adapter_28(a, state0.b, arg0, arg1);
-            } finally {
-                state0.a = a;
-            }
-        };
-        const ret = new Promise(cb0);
-        return addHeapObject(ret);
-    } finally {
-        state0.a = state0.b = 0;
-    }
-};
+	try {
+		var state0 = { a: arg0, b: arg1 };
+		var cb0 = (arg0, arg1) => {
+			const a = state0.a;
+			state0.a = 0;
+			try {
+				return __wbg_adapter_28(a, state0.b, arg0, arg1);
+			} finally {
+				state0.a = a;
+			}
+		};
+		const ret = new Promise(cb0);
+		return addHeapObject(ret);
+	} finally {
+		state0.a = state0.b = 0;
+	}
+}
 
 export function __wbg_resolve_6e1c6553a82f85b7(arg0) {
-    const ret = Promise.resolve(getObject(arg0));
-    return addHeapObject(ret);
-};
+	const ret = Promise.resolve(getObject(arg0));
+	return addHeapObject(ret);
+}
 
 export function __wbg_then_3ab08cd4fbb91ae9(arg0, arg1) {
-    const ret = getObject(arg0).then(getObject(arg1));
-    return addHeapObject(ret);
-};
+	const ret = getObject(arg0).then(getObject(arg1));
+	return addHeapObject(ret);
+}
 
 export function __wbindgen_throw(arg0, arg1) {
-    throw new Error(getStringFromWasm0(arg0, arg1));
-};
+	throw new Error(getStringFromWasm0(arg0, arg1));
+}
 
 export function __wbindgen_closure_wrapper37(arg0, arg1, arg2) {
-    const ret = makeMutClosure(arg0, arg1, 8, __wbg_adapter_16);
-    return addHeapObject(ret);
-};
-
+	const ret = makeMutClosure(arg0, arg1, 8, __wbg_adapter_16);
+	return addHeapObject(ret);
+}

--- a/src/lib/spow/spow-wasm_bg.wasm.d.ts
+++ b/src/lib/spow/spow-wasm_bg.wasm.d.ts
@@ -3,8 +3,17 @@
 export const memory: WebAssembly.Memory;
 export function pow_work_wasm(a: number, b: number): number;
 export const __wbindgen_export_0: WebAssembly.Table;
-export function wasm_bindgen__convert__closures__invoke1_mut__h2e9cd75cf14ef9ff(a: number, b: number, c: number): void;
+export function wasm_bindgen__convert__closures__invoke1_mut__h2e9cd75cf14ef9ff(
+	a: number,
+	b: number,
+	c: number
+): void;
 export function __wbindgen_malloc(a: number, b: number): number;
 export function __wbindgen_realloc(a: number, b: number, c: number, d: number): number;
 export function __wbindgen_exn_store(a: number): void;
-export function wasm_bindgen__convert__closures__invoke2_mut__h34cef696552b2b1d(a: number, b: number, c: number, d: number): void;
+export function wasm_bindgen__convert__closures__invoke2_mut__h34cef696552b2b1d(
+	a: number,
+	b: number,
+	c: number,
+	d: number
+): void;

--- a/src/routes/(app)/auth/v1/oidc/authorize/+page.svelte
+++ b/src/routes/(app)/auth/v1/oidc/authorize/+page.svelte
@@ -205,7 +205,7 @@
 				{#if providers}
 					<div class="flex w-full flex-col items-center">
 						<div>Or Login With</div>
-						<div class="providers mt-2 flex-col flex gap-2">
+						<div class="providers mt-2 flex flex-col gap-2">
 							{#each providers as provider}
 								<button
 									class="variant-outline btn w-full"
@@ -214,9 +214,13 @@
 										providerLogin(provider.id);
 									}}
 								>
-									<div class="flex flex-row gap-3 items-center">
+									<div class="flex flex-row items-center gap-3">
 										<span class="providerName">{provider.name}</span>
-										<img src={`/auth/v1/providers/${provider.id}/img`} alt={provider.name} style="width: 20px; height: 20px;" />
+										<img
+											src={`/auth/v1/providers/${provider.id}/img`}
+											alt={provider.name}
+											style="width: 20px; height: 20px;"
+										/>
 									</div>
 								</button>
 							{/each}

--- a/src/routes/(app)/auth/v1/oidc/logout/+page.svelte
+++ b/src/routes/(app)/auth/v1/oidc/logout/+page.svelte
@@ -4,7 +4,9 @@
 
 	onMount(async () => {
 		const url = new URL(window.location.href);
-		const postLogoutUri = decodeURIComponent(url.searchParams.get('post_logout_redirect_uri') || '/');
+		const postLogoutUri = decodeURIComponent(
+			url.searchParams.get('post_logout_redirect_uri') || '/'
+		);
 		const token = url.searchParams.get('id_token_hint');
 		const state = url.searchParams.get('state');
 

--- a/src/routes/(app)/auth/v1/providers/callback/+page.svelte
+++ b/src/routes/(app)/auth/v1/providers/callback/+page.svelte
@@ -50,7 +50,7 @@
 	});
 </script>
 
-<main class="flex justify-center items-center pt-8">
+<main class="flex items-center justify-center pt-8">
 	{#if error}
 		<aside class="alert variant-ghost-error min-w-[50%] max-w-3xl">
 			<!-- Message -->

--- a/src/routes/(app)/feedback/+page.svelte
+++ b/src/routes/(app)/feedback/+page.svelte
@@ -11,10 +11,7 @@
 </svelte:head>
 
 <main class="flex flex-col items-center">
-	<form
-		class="card mt-12 flex w-[600px] max-w-[90%] flex-col gap-4 p-8"
-		method="post"
-	>
+	<form class="card mt-12 flex w-[600px] max-w-[90%] flex-col gap-4 p-8" method="post">
 		<h1 class="my-3 text-center text-2xl">Leave Feedback or Request Help</h1>
 
 		<p class="text-surface-500-400-token text-center">

--- a/src/routes/(app)/feedback/confirmation/+page.svelte
+++ b/src/routes/(app)/feedback/confirmation/+page.svelte
@@ -8,7 +8,7 @@
 
 <main class="flex flex-col items-center">
 	<div class="card mt-12 flex w-[600px] max-w-[90%] flex-col gap-4 p-8">
-		Your feedback was sent! Thank you for leaving a message, we may get back to you if you
-		supplied an email address. 
+		Your feedback was sent! Thank you for leaving a message, we may get back to you if you supplied
+		an email address.
 	</div>
 </main>

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -12,7 +12,7 @@ const config = {
 		csrf: {
 			// TODO: Evaluate ways to turn this off only for the `/auth/v1/oidc/token` endpoint.
 			// We have to disable it for now because it breaks the OIDC client flow.
-			checkOrigin: false,
+			checkOrigin: false
 		}
 	}
 };

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,6 +9,6 @@ export default defineConfig({
 	server: {
 		host: '0.0.0.0',
 		port: 9523,
-		strictPort: true,
+		strictPort: true
 	}
 });


### PR DESCRIPTION
Hi, there.

I've found some inconsistencies in the code. So, perhaps this PR will solve the issue.

This PR adds:
- [typos by crate-ci](https://github.com/crate-ci/typos), to fix and check for typos.
- [dprint by dprint](https://github.com/dprint/dprint), to properly format markdown, YAML, and Dockerfile files.

The mentioned tools are also included inside the `justfile`. So, one is able to check locally just using `just fmt` or `just fmt-check`.

The repo had `prettier` and `eslint` already, but it seems they were not used in previous commits. So, I have added both to CI and the just recipe too.

I use `ci:` as the commit prefix here. If these commits should belong under a different category, I'd be happy to change it.

One last step is fixing the error that comes from `eslint`:

```
Oops! Something went wrong! :(

ESLint: 8.57.0

Error: Error while loading rule '@typescript-eslint/no-floating-promises': You have used a rule which requires parserServices to be generated. You must therefore provide a value for the "parserOptions.project" property for @typescript-eslint/parser.
```

