### PR TITLE
fix: ensure the footer always stays at the bottom

### DIFF
--- a/src/lib/components/layouts/DefaultLayout.svelte
+++ b/src/lib/components/layouts/DefaultLayout.svelte
@@ -71,15 +71,16 @@
 	</svelte:fragment>
 </AppBar>
 
-<slot></slot>
+<div class="flex min-h-screen flex-col">
+	<div class="flex-grow">
+		<slot></slot>
+	</div>
 
-<div class="mt-12 text-center text-xs text-surface-500">
-	Avatars generated with
-	<a class="underline" href="https://dicebear.com">DiceBear</a> and the
-	<a class="underline" href={`https://dicebear.com/styles/${env.PUBLIC_DICEBEAR_STYLE}`}
-		>{env.PUBLIC_DICEBEAR_STYLE}</a
-	> style.
+	<footer class="sticky bottom-0 p-4 text-center text-xs text-surface-500">
+		Avatars generated with
+		<a class="underline" href="https://dicebear.com">DiceBear</a> and the
+		<a class="underline" href={`https://dicebear.com/styles/${env.PUBLIC_DICEBEAR_STYLE}`}
+			>{env.PUBLIC_DICEBEAR_STYLE}</a
+		> style.
+	</footer>
 </div>
-
-<style>
-</style>


### PR DESCRIPTION
Before:

![image](https://github.com/commune-os/weird/assets/17734314/2271a9e1-fc39-4a76-8472-0d8e7bdea6fa)
![image](https://github.com/commune-os/weird/assets/17734314/be78c88e-a1d9-4eb3-aa7a-a7330842b14a)

After:

![image](https://github.com/commune-os/weird/assets/17734314/8c607913-b1bb-413b-aff9-0a24260c0a4d)
![image](https://github.com/commune-os/weird/assets/17734314/66589762-ef65-4a8a-8ff8-7891859a73e1)
