### PR TITLE
fix: broken mastodon links

### DIFF
--- a/src/routes/(app)/u/[username]/mastodon/+page.svelte
+++ b/src/routes/(app)/u/[username]/mastodon/+page.svelte
@@ -73,6 +73,14 @@
 		}
 		fetchStatuses(reblog_flag, last_fetched_status_id);
 	};
+
+	const parseLink = (text: string) => {
+		const parser = new DOMParser();
+		const doc = parser.parseFromString(text, 'text/html');
+		const a = doc.querySelector('a');
+		if (a) return a.getAttribute('href');
+		return '';
+	};
 </script>
 
 <svelte:head>
@@ -133,7 +141,7 @@
 			<div class="justify-start md:flex md:flex-wrap md:items-center">
 				{#each mastodon_profile.fields as field}
 					<a
-						href={field.value}
+						href={parseLink(field.value)}
 						class="y-2 mx-3 my-2 block rounded bg-white px-3 py-1 shadow hover:bg-gray-50 dark:bg-slate-800 md:mx-1 md:my-1 md:rounded-xl"
 						target="_blank"
 						rel="noopener noreferrer"


### PR DESCRIPTION
Fixes the incorrect Mastodon `links` hyperlink, which was retrieved from Mastodon's API, by implementing a parser function specifically designed to extract the correct link directly.

![](https://media.discordapp.net/attachments/944525665854701588/1261070783241781368/image.png?ex=669247f0&is=6690f670&hm=aaf4bf0d1386f9909451ead6f9ae8c3a1c7998f03891e33513e88253b6ad7858&=&format=webp&quality=lossless&width=548&height=442)

