### PR TITLE
fix: user is redirected to a 404 page when username and custom domain is not set

### DIFF
--- a/src/routes/(app)/auth/v1/account/+page.server.ts
+++ b/src/routes/(app)/auth/v1/account/+page.server.ts
@@ -49,7 +49,7 @@ export const load: PageServerLoad = async ({
 		const resp = await backendFetch(fetch, `/profile/${userInfo.id}`);
 		const profile: Profile = await resp.json();
 
-		if (cookies.get('justLoggedIn')) {
+		if (cookies.get('justLoggedIn') && (profile.custom_domain || profile.username)) {
 			const userDomain =
 				profile.custom_domain || `${profile.username?.split('@')[0] || ''}.${env.PUBLIC_DOMAIN}`;
 


### PR DESCRIPTION
Fixing the bug of #93: When the username is not defined, the website redirects the user to a 404 page (`http://.(public page)/pubpage-auth-callback?token=(token)`)