### PR TITLE
feat: inline-editing for tags, links and working capacity

### DIFF
--- a/src/lib/components/pubpage-admin/edit-links.svelte
+++ b/src/lib/components/pubpage-admin/edit-links.svelte
@@ -1,0 +1,31 @@
+<script lang="ts">
+	export let label: string;
+	export let url: string;
+	export let open = false;
+	export let saveCallback: (label: string, url: string) => void;
+</script>
+
+{#if open}
+	<dialog open>
+		<article>
+			<header>
+				<button aria-label="Close" rel="prev" onclick={() => (open = false)}></button>
+				<p>
+					<strong>Edit tags</strong>
+				</p>
+			</header>
+			<form>
+				<label>
+					<span>Label</span>
+					<input type="text" bind:value={label} />
+				</label>
+				<label>
+					<span>URL</span>
+					<input type="text" bind:value={url} />
+				</label>
+				<button type="submit" onclick={() => saveCallback(label, url)}>Save</button>
+				<button type="submit" class="secondary" onclick={() => saveCallback('', '')}>Delete</button>
+			</form>
+		</article>
+	</dialog>
+{/if}


### PR DESCRIPTION
Making the pubpage fully customizable by adding the inline editing feature for tags, links, and working capacity. The links editor was implemented with a dedicated modal form, while tags and working capacity were made editable using the `contenteditable` and `bind:value` features.