### PR TITLE
Feat: Allow editing profile Links in list

### DIFF
--- a/src/lib/components/editors/LinksEditor.svelte
+++ b/src/lib/components/editors/LinksEditor.svelte
@@ -114,10 +114,17 @@
 	>
 
 	<div class="mb-4 flex flex-col">
-		<SortableList direction="vertical" gap={0.5} on:sort={handleSort}>
+		<SortableList
+			direction="vertical"
+			hasBoundaries={true}
+			hasLockedAxis={true}
+			gap={0.5}
+			on:sort={handleSort}
+		>
 			{#each localLinks as link, index (getId(link))}
 				{@const isLast = index === localLinks.length - 1}
 				<!-- would use isLocked but it seems to be disabling input.-->
+				<!-- interactive elements lose values while dragging. fixed in v0.10.11 https://github.com/rodrigodagostino/svelte-sortable-list/issues/11 -->
 				<SortableItem id={getId(link)} {index}>
 					<div class="flex w-full items-center justify-center gap-2">
 						<div


### PR DESCRIPTION
Partially fixes   .#295, allowing Page links to be edited and reordered on the Profile edit page. 

https://github.com/user-attachments/assets/8b244070-66b8-4734-98f9-8032ba7bbb7c

There's some callouts in the code comments I'm adding here for visibility:
- Sorting here is also affected by the bug the #300 fixes, but works correctly if that is also merged.
- rodrigodagostino/svelte-sortable-list#11. This was fixed in svelte-sortable-list v0.10.11. I didn't want to edit package.json without explaining why first.
- The last empty element can get dragged into the list (and then erased). There isn't a way to lock it while leaving it editable. Opened an issue for it here (rodrigodagostino/svelte-sortable-list#15)
- Tab order for sortable covers the individual inputs. Not sure how to best to accessibly deal with this.
- Copied and edited some $effects from SocialLinksEditor.svelte to keep an empty input on the list. Might be worth abstracting and merging if the same thing is needed in more places. 
- Links get auto removed when the url is empty without checking the label. I don't know which would make more sense / how likely someone is to delete an entire url when they plan to reuse it's label.